### PR TITLE
fix bug with handling empty file

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ FA.prototype._readReverse = function (start, end, cb, rev) {
                         cb(null, Buffer(xs));
                     });
                 }
-                else if (lines.length) {
+                else if (lines && lines.length) {
                     cb(null, Buffer(lines[0]));
                 }
                 return cb(null, null);


### PR DESCRIPTION
lines can be null for an empty file, in particular if you do something like

`slice(<empty file>).sliceReverse(-1,1)`