### PR TITLE
add gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+
+test/data/follow.txt
+test/data/write.txt


### PR DESCRIPTION
While experienced users may have set up their computers to ignore e.g. `node_modules`, most beginners don't. In order to lower the barrier for everyone to contribute, this PR introduces a `.gitignore`.